### PR TITLE
Use a lua expression as the tabline variable (and other enhancements)

### DIFF
--- a/lua/buftabline/build.lua
+++ b/lua/buftabline/build.lua
@@ -44,9 +44,5 @@ return function()
         table.insert(labels, separator)
     end
 
-    if o.get().auto_hide then
-        vim.o.showtabline = #tabs > 1 and 2 or 0
-    end
-
-    vim.o.tabline = table.concat(labels)
+    return table.concat(labels)
 end

--- a/lua/buftabline/commands.lua
+++ b/lua/buftabline/commands.lua
@@ -51,7 +51,7 @@ M.toggle_tabline = function()
     vim.o.showtabline = vim.o.showtabline > 0 and 0 or 2
 end
 
-M.check_auto_hide = function()
+M.check_auto_hide = vim.schedule_wrap(function()
     if not o.get().auto_hide then
         return
     end
@@ -64,7 +64,7 @@ M.check_auto_hide = function()
     end
 
     vim.o.showtabline = num_tabs > 1 and 2 or 0
-end
+end)
 
 M.on_buffer_add = b.on_buffer_add
 M.on_buffer_delete = b.on_buffer_delete
@@ -73,7 +73,7 @@ M.on_vim_enter = b.on_vim_enter
 
 M.reset_icon_colors = function()
     h.reset()
-    vim.cmd 'redrawtabline'
+    vim.cmd("redrawtabline")
 end
 
 return M

--- a/lua/buftabline/commands.lua
+++ b/lua/buftabline/commands.lua
@@ -51,27 +51,29 @@ M.toggle_tabline = function()
     vim.o.showtabline = vim.o.showtabline > 0 and 0 or 2
 end
 
+M.check_auto_hide = function()
+    if not o.get().auto_hide then
+        return
+    end
+
+    local bufs = b.getbufinfo()
+    local num_tabs = #bufs
+    local tabnrs = vim.api.nvim_list_tabpages()
+    if #tabnrs > 1 or o.get().show_tabpages == "always" then
+        num_tabs = num_tabs + #tabnrs
+    end
+
+    vim.o.showtabline = num_tabs > 1 and 2 or 0
+end
+
 M.on_buffer_add = b.on_buffer_add
 M.on_buffer_delete = b.on_buffer_delete
 M.on_tab_closed = b.on_tab_closed
 M.on_vim_enter = b.on_vim_enter
 
-M.build = function()
-    vim.schedule(function()
-        local _, err = xpcall(require("buftabline.build"), debug.traceback)
-        if not err then
-            return
-        end
-
-        u.echo_warning("Something went wrong!: " .. err)
-        vim.o.tabline = ""
-        u.clear_augroup()
-    end)
-end
-
 M.reset_icon_colors = function()
     h.reset()
-    M.build()
+    vim.cmd 'redrawtabline'
 end
 
 return M

--- a/lua/buftabline/init.lua
+++ b/lua/buftabline/init.lua
@@ -41,11 +41,11 @@ M.setup = function(opts)
     if vim.v.vim_did_enter == 1 then
         M.__load()
     else
-        vim.cmd [[
+        vim.cmd([[
             augroup BuftablineLoad
                 autocmd VimEnter * ++once lua require('buftabline').__load()
             augroup END
-        ]]
+        ]])
     end
 end
 

--- a/lua/buftabline/init.lua
+++ b/lua/buftabline/init.lua
@@ -5,31 +5,48 @@ local M = {}
 
 M.map = u.map
 
-M.setup = function(opts)
-    opts = opts or {}
-    o.set(opts)
+M.__load = function()
+    local opts = o.get()
 
-    if not o.get().disable_commands then
+    u.clear_augroup()
+
+    if not opts.disable_commands then
         u.define_command("ToggleBuftabline", "toggle_tabline()")
         u.define_command("BufNext", "next_buffer()")
         u.define_command("BufPrev", "prev_buffer()")
     end
-    if o.get().go_to_maps then
+    if opts.go_to_maps then
         u.map({ prefix = "<Leader>", cmd = "buffer" })
     end
 
-    u.define_autocmd("BufAdd,BufEnter", "on_buffer_add()")
+    u.define_autocmd("BufAdd", "on_buffer_add()")
     u.define_autocmd("BufDelete", "on_buffer_delete()")
     u.define_autocmd("TabClosed", "on_tab_closed()")
-    u.define_autocmd("VimEnter", "on_vim_enter()")
-    u.define_autocmd("BufAdd,BufEnter,BufDelete,BufModifiedSet,TabEnter,TabClosed,WinEnter", "build()")
+    u.define_autocmd("SessionLoadPost", "on_vim_enter()")
+    u.define_autocmd("BufEnter,BufUnload,TabNew,TabClosed", "check_auto_hide()")
 
-    if o.get().icon_colors then
+    if opts.icon_colors then
         u.define_autocmd("ColorScheme", "reset_icon_colors()")
         u.define_autocmd("OptionSet", "reset_icon_colors()", "background")
     end
 
-    vim.o.showtabline = (o.get().start_hidden or o.get().auto_hide) and 0 or 2
+    vim.o.tabline = [[%!luaeval('require("buftabline.build")()')]]
+    vim.o.showtabline = (opts.start_hidden or opts.auto_hide) and 0 or 2
+end
+
+M.setup = function(opts)
+    opts = opts or {}
+    o.set(opts)
+
+    if vim.v.vim_did_enter == 1 then
+        M.__load()
+    else
+        vim.cmd [[
+            augroup BuftablineLoad
+                autocmd VimEnter * ++once lua require('buftabline').__load()
+            augroup END
+        ]]
+    end
 end
 
 return M

--- a/test/buftabline_spec.lua
+++ b/test/buftabline_spec.lua
@@ -15,14 +15,8 @@ local close_all = function()
     vim.cmd("bufdo! bwipeout!")
 end
 
-local wait_for_scheduler = function()
-    vim.wait(0)
-end
-
 local assert_tabline = function(expected)
-    wait_for_scheduler()
-
-    assert.equals(vim.trim(vim.o.tabline), expected)
+    assert.equals(expected, vim.trim(buftabline()))
 end
 
 local assert_current = function(name)
@@ -30,7 +24,7 @@ local assert_current = function(name)
 end
 
 describe("buftabline", function()
-    require("buftabline").setup()
+    require("buftabline").__load()
 
     after_each(function()
         vim.o.columns = 80
@@ -235,26 +229,21 @@ describe("buftabline", function()
         it("should hide tabline if only one tab is open", function()
             edit_mock_files(1)
 
-            wait_for_scheduler()
-
-            assert.equals(vim.o.showtabline, 0)
+            assert.equals(0, vim.o.showtabline)
         end)
 
         it("should show tabline if more than one tab is open", function()
             edit_mock_files(2)
 
-            wait_for_scheduler()
-
-            assert.equals(vim.o.showtabline, 2)
+            assert.equals(2, vim.o.showtabline)
         end)
 
         it("should hide on buffer close if only one tab is left", function()
             edit_mock_files(2)
 
             vim.cmd("bdelete")
-            wait_for_scheduler()
 
-            assert.equals(vim.o.showtabline, 0)
+            assert.equals(0, vim.o.showtabline)
         end)
     end)
 

--- a/test/buftabline_spec.lua
+++ b/test/buftabline_spec.lua
@@ -1,3 +1,4 @@
+local build = require("buftabline.build")
 local o = require("buftabline.options")
 
 local input = function(keys)
@@ -16,7 +17,7 @@ local close_all = function()
 end
 
 local assert_tabline = function(expected)
-    assert.equals(expected, vim.trim(buftabline()))
+    assert.equals(expected, vim.trim(build()))
 end
 
 local assert_current = function(name)
@@ -69,77 +70,6 @@ describe("buftabline", function()
             vim.cmd("e " .. vim.fn.getcwd() .. "/test/test1.lua")
 
             assert_tabline("%#TabLineFill# 1: buftabline.nvim/test1.lua %*%#TabLineSel# 2: test/test1.lua %*")
-        end)
-    end)
-
-    describe("events", function()
-        before_each(function()
-            vim.o.columns = 32
-            edit_mock_files(1)
-        end)
-
-        it("should update on BufAdd", function()
-            vim.cmd("e newfile")
-
-            assert_tabline("%#TabLineFill# 1: test1.lua %*%#TabLineSel# 2: newfile %*")
-        end)
-
-        it("should update on BufEnter", function()
-            vim.cmd("e newfile")
-
-            vim.cmd("bprev")
-
-            assert_tabline("%#TabLineSel# 1: test1.lua %*%#TabLineFill# 2: newfile %*")
-        end)
-
-        it("should update on BufDelete", function()
-            vim.cmd("bdelete")
-
-            assert_tabline("")
-        end)
-
-        it("should update on BufModifiedSet", function()
-            vim.cmd("normal Atest")
-
-            assert_tabline("%#TabLineSel# 1: test1.lua [+] %*")
-        end)
-
-        it("should update on TabEnter (new)", function()
-            vim.cmd("tabnew")
-
-            assert_tabline("%#TabLineFill# 1: test1.lua %*            %#TabLineFill# 1 %*%#TabLineSel# 2 %*")
-        end)
-
-        it("should update on TabEnter (change)", function()
-            vim.cmd("tabnew")
-
-            vim.cmd("tabprev")
-
-            assert_tabline("%#TabLineSel# 1: test1.lua %*            %#TabLineSel# 1 %*%#TabLineFill# 2 %*")
-        end)
-
-        it("should update on TabClose", function()
-            vim.cmd("tabnew")
-
-            vim.cmd("tabclose")
-
-            assert_tabline("%#TabLineSel# 1: test1.lua %*")
-        end)
-
-        it("should update on WinEnter (new)", function()
-            vim.cmd("split")
-            vim.cmd("e newfile")
-
-            assert_tabline("%#TabLineFill# 1: test1.lua %*%#TabLineSel# 2: newfile %*")
-        end)
-
-        it("should update on WinEnter (change)", function()
-            vim.cmd("split")
-            vim.cmd("e newfile")
-
-            vim.cmd("wincmd p")
-
-            assert_tabline("%#TabLineSel# 1: test1.lua %*%#TabLineFill# 2: newfile %*")
         end)
     end)
 
@@ -229,11 +159,15 @@ describe("buftabline", function()
         it("should hide tabline if only one tab is open", function()
             edit_mock_files(1)
 
+            vim.wait(0)
+
             assert.equals(0, vim.o.showtabline)
         end)
 
         it("should show tabline if more than one tab is open", function()
             edit_mock_files(2)
+
+            vim.wait(0)
 
             assert.equals(2, vim.o.showtabline)
         end)
@@ -242,6 +176,7 @@ describe("buftabline", function()
             edit_mock_files(2)
 
             vim.cmd("bdelete")
+            vim.wait(0)
 
             assert.equals(0, vim.o.showtabline)
         end)


### PR DESCRIPTION
Use a lua expression as the tabline variable. This means we don't
have to rely on autocmd events to do a rebuild of the tabline since we
can just rely on nvim's built-in re-eval logic.

This both improves performance as well as correctness. The tabline will
only be redrawn when neovim knows something has changed. This includes
saving buffers (so they are no longer modified) on non-visible buffers
(fixes #21).

Because we aren't repeatedly updating the tabline option (relying on the
built-in eval logic), the start/help screen when vim is first opened is
no longer immediately erased which fixes #22.

Loading buftabline will now occur on VimEnter if it is autoloaded at
startup, but will occur synchronously if re-loaded or if it's
lazy-initialized.