### PR TITLE
Remove padding from flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ local options = {
     disable_commands = false,
     go_to_maps = true,
     flags = {
-        modified = "[+]",
-        not_modifiable = "[-]",
-        readonly = "[RO]",
+        modified = " [+]",
+        not_modifiable = " [-]",
+        readonly = " [RO]",
     },
     hlgroups = {
         current = "TabLineSel",

--- a/lua/buftabline/buftab.lua
+++ b/lua/buftabline/buftab.lua
@@ -32,7 +32,7 @@ function Buftab:generate_flags()
         table.insert(buffer_flags, flags.readonly)
     end
     if vim.tbl_count(buffer_flags) > 0 then
-        table.insert(buffer_flags, 1, " ")
+        table.insert(buffer_flags, 1, "")
     end
     self.flags = table.concat(buffer_flags)
 end

--- a/lua/buftabline/options.lua
+++ b/lua/buftabline/options.lua
@@ -7,9 +7,9 @@ local defaults = {
     disable_commands = false,
     go_to_maps = true,
     flags = {
-        modified = "[+]",
-        not_modifiable = "[-]",
-        readonly = "[RO]",
+        modified = " [+]",
+        not_modifiable = " [-]",
+        readonly = " [RO]",
     },
     hlgroups = {
         current = "TabLineSel",


### PR DESCRIPTION
First of all: Nice plugin! :grin:

Secondly, I noticed that when we have the flags option set to true (in order to see the `[+]` in modified buffers, for example), a space was added between the file name and the flag:\
![image](https://user-images.githubusercontent.com/60318892/143373970-3e2af7d4-583b-467d-ad91-ed0fc2f72d18.png)

Even though this looks like a sane default, I personally would prefer without that little space:\
![image](https://user-images.githubusercontent.com/60318892/143375344-f2da25b8-9797-463e-813f-f50fdf835976.png)

This PR implements this idea of removing this extra space (which I called "flag padding") reasoning that if we want the flag padding, we can easily achieve it by changing the flag string from `"[+]"` to `" [+]"` in the setup, so we are not losing any possibility here.

I imagine that the default flags should actually have that extra space there, so the sane default would remain.\
Also, the tests are expecting the flag padding, so changing the defaults made the tests pass :grimacing::+1:

What do you think?